### PR TITLE
simple payment config for stripe subscription

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
 
     <meta property="og:locale:alternate" content="en_US">
 
+    <!-- Load Stripe.js on your website. -->
+    <script src="https://js.stripe.com/v3/"></script>
+
     <script type="text/javascript">
         var userLang = navigator.language || navigator.userLanguage;
         if (userLang == "fr") {
@@ -78,7 +81,7 @@
     </header>
 
     <aside>
-        <form>
+        <form id="membership-form">
             <h3>Title goes here</h3>
             <h4><em>Sub</em>/title</h4>
             <label for="name">name</label>
@@ -139,6 +142,7 @@
             <p>Made with ❤️ by people from <a href="https://dev.ngo" rel="noopener">The Developer Society</a>.</p>
         </div>
     </footer>
+    <script src="/static/js/form.js"></script>
 </body>
 
 </html>

--- a/static/js/form.js
+++ b/static/js/form.js
@@ -1,0 +1,44 @@
+const form = document.getElementById('membership-form')
+const submitButton = form.querySelector('button[type=submit]')
+
+const makeStripePayment = () => {
+  // Replace with your own publishable key: https://dashboard.stripe.com/test/apikeys
+  var PUBLISHABLE_KEY = 'pk_test_WCJLe4VIHyg3wdUQYvMaBa5K00z9hFMGJ2';
+  // Replace with the domain you want your users to be redirected back to after payment
+  var DOMAIN = location.href.replace(/[^/]*$/, '');
+
+  var stripe = Stripe(PUBLISHABLE_KEY);
+
+  // Handle any errors from Checkout
+  var handleResult = function (result) {
+    if (result.error) {
+      var displayError = document.getElementById('error-message');
+      displayError.textContent = result.error.message;
+    }
+  };
+
+    // Make the call to Stripe.js to redirect to the checkout page
+    // with the sku or plan ID.
+    stripe
+      .redirectToCheckout({
+        mode: 'subscription',
+        lineItems: [{ price: 'price_1JjQ5LAL5YtKKJj5KS3lH6U9', quantity: 1 }],
+        successUrl:
+          DOMAIN + 'success.html?session_id={CHECKOUT_SESSION_ID}',
+        cancelUrl:
+          DOMAIN + 'canceled.html?session_id={CHECKOUT_SESSION_ID}',
+      })
+      .then(handleResult);
+  }
+
+
+const handleSubmit = (event) => {
+  event.preventDefault()
+  submitButton.disabled = true
+
+  makeStripePayment()
+}
+
+if (form) {
+  form.onsubmit = handleSubmit
+}

--- a/success.html
+++ b/success.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <h1>Success!</h1>
+</body>
+</html>


### PR DESCRIPTION
Card: https://app.forecast.it/T9169

**Description**
- Basic config for stripe payments
- When the form is submitted. User is taken to stripe payment view and after, redirected to success.html
- Stripe test credentials are for my account and hard coded. May enhance later to use `dotenv` to store the credentials.

**set up instructions**
run a simple server using `python3 -m http.server`

i aliased this to `simpleserver` as it's quite handy for serving some static files locally. 

```
# .bash_profile
alias simpleserver="python3 -m http.server"
```

**Test**
- click sign me up and enter test card details 
  - Card no: `4111111111111111` 
  - Exp: `02/23` 
  - cvc: `123`
  
 - check the payment works and you are taken to the success view.